### PR TITLE
release: v4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "pinst": "^3.0.0",
     "rollup": "^2.75.7",
     "typescript": "^4.7.4",
-    "vitest": "^0.15.1"
+    "vitest": "^0.15.2"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/toc-generator",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "GitHub Action to generate TOC.",
   "keywords": [
     "github",

--- a/src/utils/misc.test.ts
+++ b/src/utils/misc.test.ts
@@ -39,7 +39,7 @@ describe('getRunnerArguments', () => {
     expect(args).toHaveProperty('executeCommands');
     delete args.executeCommands;
     expect(args).toEqual({
-      rootDir: rootDir,
+      rootDir: path.resolve(__dirname, '..'),
       actionName: 'TOC Generator',
       actionOwner: 'technote-space',
       actionRepo: 'toc-generator',
@@ -139,7 +139,7 @@ describe('getRunnerArguments', () => {
     const args = getRunnerArguments();
     delete args.logger;
     expect(args).toEqual({
-      rootDir: rootDir,
+      rootDir: path.resolve(__dirname, '..'),
       actionName: 'TOC Generator',
       actionOwner: 'technote-space',
       actionRepo: 'toc-generator',

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -38,7 +38,7 @@ const getExecuteCommands = (logger: Logger): Array<ExecuteTask> => {
 export const getRunnerArguments = (): MainArguments => {
   const logger = new Logger(replaceDirectory);
   return {
-    rootDir: resolve(__dirname, '../..'),
+    rootDir: resolve(__dirname, '..'),
     logger,
     actionName: ACTION_NAME,
     actionOwner: ACTION_OWNER,

--- a/yarn.lock
+++ b/yarn.lock
@@ -264,7 +264,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.7":
+"@jridgewell/trace-mapping@^0.3.12":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz#dcfe3e95f224c8fe97a87a5235defec999aa92ea"
   integrity sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==
@@ -1365,131 +1365,131 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild-android-64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.46.tgz#98d019853ca7b526d0d645bb4618fda425b74d35"
-  integrity sha512-ZyJqwAcjNbZprs0ZAxnUAOhEhdE5kTKwz+CZuLmZYNLAPyRgBtaC8pT2PCuPifNvV8Cl3yLlrQPaOCjovoyb5g==
+esbuild-android-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz#ef95b42c67bcf4268c869153fa3ad1466c4cea6b"
+  integrity sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==
 
-esbuild-android-arm64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.46.tgz#19835d5265b57120c14fba56a19fc317ca4bbda0"
-  integrity sha512-BKcnUksvCijO9ONv6b4SikZE/OZftwJvX91XROODZGQmuwGVg97jmLDVu3lxuHdFlMNNzxh8taJ2mbCWZzH/Iw==
+esbuild-android-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz#4ebd7ce9fb250b4695faa3ee46fd3b0754ecd9e6"
+  integrity sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==
 
-esbuild-darwin-64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.46.tgz#2819465ab92f6df407e6462d9e56f6563a043a44"
-  integrity sha512-/ss2kO92sUJ9/1nHnMb3+oab8w6dyqKrMtPMvSYJ9KZIYGAZxz/WYxfFprY7Xk+ZxWnnlASSyZlG+If1nVmFYg==
+esbuild-darwin-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz#e0da6c244f497192f951807f003f6a423ed23188"
+  integrity sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==
 
-esbuild-darwin-arm64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.46.tgz#2d523fa628930bba38a4f75cede75d6341bc3b5b"
-  integrity sha512-WX0JOaEFf6t+rIjXO6THsf/0fhQAt2Zb0/PSYlvXnuQQAmOmFAfPsuRNocp5ME0NGaUqZd4FxqqmLEVK3RzPAg==
+esbuild-darwin-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz#cd40fd49a672fca581ed202834239dfe540a9028"
+  integrity sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==
 
-esbuild-freebsd-64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.46.tgz#dbfbbb1cb943149aaa83b9e767ded6f14ad42ba5"
-  integrity sha512-o+ozPFuHRCAGCVWU2bLurOUgVkT0jcPEu082VBUY2Q/yLf+B+/3nXzh4Fjp5O21tOvJRTn7hUVydG9j5+vYE6A==
+esbuild-freebsd-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz#8da6a14c095b29c01fc8087a16cb7906debc2d67"
+  integrity sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==
 
-esbuild-freebsd-arm64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.46.tgz#fb066d6e7de2bd96138dd1c2fba5e8ce5233ed5a"
-  integrity sha512-9zicZ0X43WDKz3sjNfcqYO38xbfJpSWYXB+FxvYYkmBwGA52K0SAu4oKuTTLi8od8X2IIo1x5C5TUNvKDSVJww==
+esbuild-freebsd-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz#ad31f9c92817ff8f33fd253af7ab5122dc1b83f6"
+  integrity sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==
 
-esbuild-linux-32@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.46.tgz#ea2464b10fe188ee7c9be81a2757e2d69ffdb8c1"
-  integrity sha512-ZnTpZMVb0VGvL99R5eh4OrJwbUyvpM6M88VAMuHP4LvFjuvZrhgefjKqEGuWZZW7JRnAjKqjXLjWdhdSjwMFnQ==
+esbuild-linux-32@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz#de085e4db2e692ea30c71208ccc23fdcf5196c58"
+  integrity sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==
 
-esbuild-linux-64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.46.tgz#f4f2d181af6ea78137311712fca423f8fa954314"
-  integrity sha512-ECCRRZtX6l4ubeVhHhiVoK/uYAkvzNqfmR4gP4N/9H9RPu+b8YCcN4bQGp7xCuYIV6Xd41WpOMyO+xpcQvjtQQ==
+esbuild-linux-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz#2a9321bbccb01f01b04cebfcfccbabeba3658ba1"
+  integrity sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==
 
-esbuild-linux-arm64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.46.tgz#113d17c523dfe80c9d4981d05c58f5ada3470e30"
-  integrity sha512-HX0TXCHyI0NEWG4jg8LlW1PbZQbnz+PUH56yjx996cgM5pC90u32drKs/tyJiyyQmNk9OXOogjKw7LEdp/Qc1w==
+esbuild-linux-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz#b9da7b6fc4b0ca7a13363a0c5b7bb927e4bc535a"
+  integrity sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==
 
-esbuild-linux-arm@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.46.tgz#1b6ba77b0301572b2fed35fe922b1613b10b5c7e"
-  integrity sha512-RvTJEi4vj13c5FP9YPp+8Y6x6HK1E7uSqfy3y9UoeaNAzNZWA7fN1U3hQjTL/dy5zTJH5KE64mrt5k5+he+CQA==
+esbuild-linux-arm@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz#56fec2a09b9561c337059d4af53625142aded853"
+  integrity sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==
 
-esbuild-linux-mips64le@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.46.tgz#8775e12510eaf988a9bc5e6787cf0c87c3eb40d6"
-  integrity sha512-jnb2NDwGqJUVmxn1v0f7seNdDm0nRNWHP9Z3MrWAGnBCdnnDlsjqRFDnbKoaQvWONEa+rOOr/giK+VL0hgQExA==
+esbuild-linux-mips64le@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz#9db21561f8f22ed79ef2aedb7bbef082b46cf823"
+  integrity sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==
 
-esbuild-linux-ppc64le@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.46.tgz#da003df59859b02e160827e26bc1e107bec23d07"
-  integrity sha512-uu3JTQUrwwauKY9z8yq5MnDyOlT3f2DNOzBcYz4dB78HqwEqilCsifoBGd0WcbED5n57dc59X+LZMTZ8Ose44w==
+esbuild-linux-ppc64le@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz#dc3a3da321222b11e96e50efafec9d2de408198b"
+  integrity sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==
 
-esbuild-linux-riscv64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.46.tgz#b6c4faf9f8482e2a898ec2becac4a6789ae3ff22"
-  integrity sha512-OB29r1EG44ZY34JnXCRERxo7k4pRKoQdaoRg2HIeCavatsXZwW4LCakpLnMQ72vXT1HtpBUABEjHkKkn5JyrUg==
+esbuild-linux-riscv64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz#9bd6dcd3dca6c0357084ecd06e1d2d4bf105335f"
+  integrity sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==
 
-esbuild-linux-s390x@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.46.tgz#d30d0f7ee8466c4ec99ac2c689b70514320406b2"
-  integrity sha512-XQ/U9TueMSGYyPTKyZsJVraiuvxhwCDIMn/QwFXCRCJ6H/Cy/Rq33u9qhpeSziinHKfzJROGx5A8mQY6aYamdQ==
+esbuild-linux-s390x@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz#a458af939b52f2cd32fc561410d441a51f69d41f"
+  integrity sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==
 
-esbuild-netbsd-64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.46.tgz#fcf2b739b63731b5b264dc584240c0b61dbbf035"
-  integrity sha512-i15BwqHaAIFp1vBJkitAbHtwXcLk9TdHs/Ia1xGIAutQYXSJNPLM3Z4B4hyfHNEFl2yBqBIYpglMohv2ClNdOQ==
+esbuild-netbsd-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz#6388e785d7e7e4420cb01348d7483ab511b16aa8"
+  integrity sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==
 
-esbuild-openbsd-64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.46.tgz#fc7880751b78b325216e66470b9a3df7b1c21cbf"
-  integrity sha512-XwOIFCE140Y/PvjrwjFfa/QLWBuvhR1mPCOa35mKx02jt++wPNgf0qhn6HfdVC3vQe7R46RwTp4q2cp99fepEg==
+esbuild-openbsd-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz#309af806db561aa886c445344d1aacab850dbdc5"
+  integrity sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==
 
-esbuild-sunos-64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.46.tgz#ab73b91e79ae53dddb035da9bb69ba7dd44d36ee"
-  integrity sha512-+kV3JnmfdxBVpHyFvuGXWtu6tXxXApOLPkSrVkMJf6+ns/3PLtPndpzwCzHjD+qYUEk8ln4MA+ufQ2qmjW5mZg==
+esbuild-sunos-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz#3f19612dcdb89ba6c65283a7ff6e16f8afbf8aaa"
+  integrity sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==
 
-esbuild-windows-32@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.46.tgz#88ad388c896325d273e92dbf28f146d1d34d4351"
-  integrity sha512-gzGC1Q11B/Bo5A2EX4N22oigWmhL7Z0eDyc8kbSoJjqSrGQuRE7B0uMpluO+q0O/gZ1S3zdw+M4PCWlqOIeXLA==
+esbuild-windows-32@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz#a92d279c8458d5dc319abcfeb30aa49e8f2e6f7f"
+  integrity sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==
 
-esbuild-windows-64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.46.tgz#bfb21b68d54d0db86190f8073cbf66a86bd0de14"
-  integrity sha512-Do2daaskfOjmCB7o3ygz6fD3K6SPjZLERiZLktzHz2oUCwsebKu/gmop0+j/XdrVIXC32wFzHzDS+9CTu9OShw==
+esbuild-windows-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz#2564c3fcf0c23d701edb71af8c52d3be4cec5f8a"
+  integrity sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==
 
-esbuild-windows-arm64@0.14.46:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.46.tgz#b8aa66a0c347342b9ae780b537d5574e9691c123"
-  integrity sha512-VEzMy6bM60/HT/URTDElyhfi2Pk0quCCrEhRlI4MRno/AIqYUGw0rZwkPl6PeoqVI6BgoBHGY576GWTiPmshCA==
+esbuild-windows-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz#86d9db1a22d83360f726ac5fba41c2f625db6878"
+  integrity sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==
 
 esbuild@^0.14.27:
-  version "0.14.46"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.46.tgz#d548cfc13fecfd4bc074ce38e0122d1dd9b067db"
-  integrity sha512-vdm5G1JdZBktva8dwQci/s44VbeBUg8g907xoZx77mqFZ4gU5GlMULNsdGeID+qXCXocsfYSGtE0LvqH3eiNQg==
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.47.tgz#0d6415f6bd8eb9e73a58f7f9ae04c5276cda0e4d"
+  integrity sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==
   optionalDependencies:
-    esbuild-android-64 "0.14.46"
-    esbuild-android-arm64 "0.14.46"
-    esbuild-darwin-64 "0.14.46"
-    esbuild-darwin-arm64 "0.14.46"
-    esbuild-freebsd-64 "0.14.46"
-    esbuild-freebsd-arm64 "0.14.46"
-    esbuild-linux-32 "0.14.46"
-    esbuild-linux-64 "0.14.46"
-    esbuild-linux-arm "0.14.46"
-    esbuild-linux-arm64 "0.14.46"
-    esbuild-linux-mips64le "0.14.46"
-    esbuild-linux-ppc64le "0.14.46"
-    esbuild-linux-riscv64 "0.14.46"
-    esbuild-linux-s390x "0.14.46"
-    esbuild-netbsd-64 "0.14.46"
-    esbuild-openbsd-64 "0.14.46"
-    esbuild-sunos-64 "0.14.46"
-    esbuild-windows-32 "0.14.46"
-    esbuild-windows-64 "0.14.46"
-    esbuild-windows-arm64 "0.14.46"
+    esbuild-android-64 "0.14.47"
+    esbuild-android-arm64 "0.14.47"
+    esbuild-darwin-64 "0.14.47"
+    esbuild-darwin-arm64 "0.14.47"
+    esbuild-freebsd-64 "0.14.47"
+    esbuild-freebsd-arm64 "0.14.47"
+    esbuild-linux-32 "0.14.47"
+    esbuild-linux-64 "0.14.47"
+    esbuild-linux-arm "0.14.47"
+    esbuild-linux-arm64 "0.14.47"
+    esbuild-linux-mips64le "0.14.47"
+    esbuild-linux-ppc64le "0.14.47"
+    esbuild-linux-riscv64 "0.14.47"
+    esbuild-linux-s390x "0.14.47"
+    esbuild-netbsd-64 "0.14.47"
+    esbuild-openbsd-64 "0.14.47"
+    esbuild-sunos-64 "0.14.47"
+    esbuild-windows-32 "0.14.47"
+    esbuild-windows-64 "0.14.47"
+    esbuild-windows-arm64 "0.14.47"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -3530,7 +3530,7 @@ tinypool@^0.1.3:
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.1.3.tgz#b5570b364a1775fd403de5e7660b325308fee26b"
   integrity sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ==
 
-tinyspy@^0.3.2:
+tinyspy@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-0.3.3.tgz#8b57f8aec7fe1bf583a3a49cb9ab30c742f69237"
   integrity sha512-gRiUR8fuhUf0W9lzojPf1N1euJYA30ISebSfgca8z76FOvXtVXqd5ojEIaKLWbDQhAaC3ibxZIjqbyi4ybjcTw==
@@ -3735,11 +3735,11 @@ v8-compile-cache@^2.0.3:
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 v8-to-istanbul@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.0.0.tgz#be0dae58719fc53cb97e5c7ac1d7e6d4f5b19511"
-  integrity sha512-HcvgY/xaRm7isYmyx+lFKA4uQmfUbN0J4M0nNItvzTvH/iQ9kW5j/t4YSR+Ge323/lrgDAWJoF46tzGQHwBHFw==
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz#b6f994b0b5d4ef255e17a0d17dc444a9f5132fa4"
+  integrity sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==
   dependencies:
-    "@jridgewell/trace-mapping" "^0.3.7"
+    "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
 
@@ -3781,10 +3781,10 @@ vite@^2.9.12:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@^0.15.1:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.15.1.tgz#8bdb42544261fa95afe8ea10bae3f315ca7e4c74"
-  integrity sha512-NaNFi93JKSuvV4YGnfQ0l0GKYxH0EsLcTrrXaCzd6qfVEZM/RJpjwSevg6waNFqu2DyN6e0aHHdrCZW5/vh5NA==
+vitest@^0.15.1, vitest@^0.15.2:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.15.2.tgz#3931c390685ff03331298c7719d27d691f79e782"
+  integrity sha512-cMabuUqu+nNHafkdN7H8Z20+UZTrrUfqjGwAoLwUwrqFGWBz3gXwxndjbLf6mgSFs9lF/JWjKeNM1CXKwtk26w==
   dependencies:
     "@types/chai" "^4.3.1"
     "@types/chai-subset" "^1.3.3"
@@ -3793,7 +3793,7 @@ vitest@^0.15.1:
     debug "^4.3.4"
     local-pkg "^0.4.1"
     tinypool "^0.1.3"
-    tinyspy "^0.3.2"
+    tinyspy "^0.3.3"
     vite "^2.9.12"
 
 webidl-conversions@^3.0.0:


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* fix: rootDir (51ab5df206a67f39864528bdc0078e06681b4a8a)
* chore: update npm dependencies (0763af3414f8edce6412bdaecfed1a2362051da3)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/toc-generator/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Using yarn
Upgrading /home/runner/work/toc-generator/toc-generator/package.json

 vitest  ^0.15.1  →  ^0.15.2     

Run yarn install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
$ [ -n "$CI" ] || [ ! -f node_modules/.bin/husky ] || husky install
Done in 14.37s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 377 new dependencies.
info Direct dependencies
├─ @commitlint/cli@17.0.2
├─ @commitlint/config-conventional@17.0.2
├─ @rollup/plugin-commonjs@22.0.0
├─ @rollup/plugin-json@4.1.0
├─ @rollup/plugin-node-resolve@13.3.0
├─ @rollup/plugin-typescript@8.3.3
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/doctoc@2.4.23
├─ @technote-space/github-action-helper@5.3.7
├─ @technote-space/github-action-log-helper@0.2.6
├─ @technote-space/github-action-pr-helper@2.3.3
├─ @technote-space/github-action-test-helper@0.9.8
├─ @technote-space/release-github-actions-cli@1.9.0
├─ @types/node@18.0.0
├─ @typescript-eslint/eslint-plugin@5.29.0
├─ @typescript-eslint/parser@5.29.0
├─ c8@7.11.3
├─ eslint-plugin-import@2.26.0
├─ eslint@8.18.0
├─ fast-glob@3.2.11
├─ husky@8.0.1
├─ lint-staged@13.0.2
├─ nock@13.2.7
├─ pinst@3.0.0
├─ rollup@2.75.7
├─ typescript@4.7.4
└─ vitest@0.15.2
info All dependencies
├─ @babel/code-frame@7.16.7
├─ @babel/helper-validator-identifier@7.16.7
├─ @babel/highlight@7.17.12
├─ @bcoe/v8-coverage@0.2.3
├─ @commitlint/cli@17.0.2
├─ @commitlint/config-conventional@17.0.2
├─ @commitlint/ensure@17.0.0
├─ @commitlint/execute-rule@17.0.0
├─ @commitlint/format@17.0.0
├─ @commitlint/is-ignored@17.0.0
├─ @commitlint/lint@17.0.0
├─ @commitlint/load@17.0.0
├─ @commitlint/message@17.0.0
├─ @commitlint/parse@17.0.0
├─ @commitlint/read@17.0.0
├─ @commitlint/resolve-extends@17.0.0
├─ @commitlint/rules@17.0.0
├─ @commitlint/to-lines@17.0.0
├─ @commitlint/top-level@17.0.0
├─ @cspotcode/source-map-support@0.8.1
├─ @eslint/eslintrc@1.3.0
├─ @humanwhocodes/config-array@0.9.5
├─ @humanwhocodes/object-schema@1.2.1
├─ @istanbuljs/schema@0.1.3
├─ @jridgewell/trace-mapping@0.3.13
├─ @nodelib/fs.scandir@2.1.5
├─ @nodelib/fs.stat@2.0.5
├─ @nodelib/fs.walk@1.2.8
├─ @octokit/auth-token@2.5.0
├─ @octokit/core@3.6.0
├─ @octokit/endpoint@6.0.12
├─ @octokit/graphql@4.8.0
├─ @octokit/openapi-types@12.4.0
├─ @octokit/plugin-paginate-rest@2.19.0
├─ @octokit/plugin-rest-endpoint-methods@5.15.0
├─ @octokit/request-error@2.1.0
├─ @octokit/request@5.6.3
├─ @rollup/plugin-commonjs@22.0.0
├─ @rollup/plugin-json@4.1.0
├─ @rollup/plugin-node-resolve@13.3.0
├─ @rollup/plugin-typescript@8.3.3
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/anchor-markdown-header@1.1.36
├─ @technote-space/doctoc@2.4.23
├─ @technote-space/filter-github-action@0.6.3
├─ @technote-space/github-action-helper@5.3.7
├─ @technote-space/github-action-log-helper@0.2.6
├─ @technote-space/github-action-pr-helper@2.3.3
├─ @technote-space/github-action-test-helper@0.9.8
├─ @technote-space/release-github-actions-cli@1.9.0
├─ @technote-space/release-github-actions@7.2.4
├─ @textlint/ast-node-types@12.1.1
├─ @textlint/markdown-to-ast@12.1.1
├─ @tsconfig/node10@1.0.9
├─ @tsconfig/node12@1.0.11
├─ @tsconfig/node14@1.0.3
├─ @tsconfig/node16@1.0.3
├─ @types/chai-subset@1.3.3
├─ @types/chai@4.3.1
├─ @types/estree@0.0.51
├─ @types/istanbul-lib-coverage@2.0.4
├─ @types/json-schema@7.0.11
├─ @types/json5@0.0.29
├─ @types/mdast@3.0.10
├─ @types/minimist@1.2.2
├─ @types/node@18.0.0
├─ @types/normalize-package-data@2.4.1
├─ @types/parse-json@4.0.0
├─ @types/resolve@1.17.1
├─ @typescript-eslint/eslint-plugin@5.29.0
├─ @typescript-eslint/parser@5.29.0
├─ @typescript-eslint/type-utils@5.29.0
├─ acorn-jsx@5.3.2
├─ acorn-walk@8.2.0
├─ acorn@8.7.1
├─ aggregate-error@3.1.0
├─ ajv@6.12.6
├─ ansi-escapes@4.3.2
├─ ansi-regex@5.0.1
├─ arg@4.1.3
├─ argparse@2.0.1
├─ array-ify@1.0.0
├─ array-includes@3.1.5
├─ array-union@2.1.0
├─ array.prototype.flat@1.3.0
├─ arrify@1.0.1
├─ assertion-error@1.1.0
├─ bail@1.0.5
├─ balanced-match@1.0.2
├─ before-after-hook@2.2.2
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ builtin-modules@3.3.0
├─ c8@7.11.3
├─ callsites@3.1.0
├─ camelcase-keys@6.2.2
├─ camelcase@5.3.1
├─ ccount@1.1.0
├─ chai@4.3.6
├─ chalk@4.1.2
├─ character-entities-legacy@1.1.4
├─ character-entities@1.2.4
├─ character-reference-invalid@1.1.4
├─ check-error@1.0.2
├─ clean-stack@2.2.0
├─ cli-cursor@3.1.0
├─ cli-truncate@3.1.0
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ colorette@2.0.19
├─ commander@9.3.0
├─ commondir@1.0.1
├─ concat-map@0.0.1
├─ conventional-changelog-angular@5.0.13
├─ conventional-changelog-conventionalcommits@5.0.0
├─ conventional-commits-parser@3.2.4
├─ convert-source-map@1.8.0
├─ cosmiconfig-typescript-loader@2.0.1
├─ cosmiconfig@7.0.1
├─ create-require@1.1.1
├─ dargs@7.0.0
├─ debug@4.3.4
├─ decamelize-keys@1.1.0
├─ decamelize@1.2.0
├─ deep-eql@3.0.1
├─ deep-is@0.1.4
├─ deepmerge@4.2.2
├─ deprecation@2.3.1
├─ diff@4.0.2
├─ dir-glob@3.0.1
├─ doctrine@2.1.0
├─ dom-serializer@1.4.1
├─ domutils@2.8.0
├─ dot-prop@5.3.0
├─ dotenv@16.0.1
├─ eastasianwidth@0.2.0
├─ emoji-regex@8.0.0
├─ entities@3.0.1
├─ error-ex@1.3.2
├─ es-shim-unscopables@1.0.0
├─ es-to-primitive@1.2.1
├─ esbuild-linux-64@0.14.47
├─ esbuild@0.14.47
├─ eslint-import-resolver-node@0.3.6
├─ eslint-module-utils@2.7.3
├─ eslint-plugin-import@2.26.0
├─ eslint-scope@7.1.1
├─ eslint@8.18.0
├─ esquery@1.4.0
├─ estraverse@5.3.0
├─ estree-walker@2.0.2
├─ extend@3.0.2
├─ fast-deep-equal@3.1.3
├─ fast-glob@3.2.11
├─ fast-json-stable-stringify@2.1.0
├─ fast-levenshtein@2.0.6
├─ fastq@1.13.0
├─ fault@1.0.4
├─ file-entry-cache@6.0.1
├─ fill-range@7.0.1
├─ flat-cache@3.0.4
├─ flatted@3.2.5
├─ foreground-child@2.0.0
├─ format@0.2.2
├─ fs-extra@10.1.0
├─ fs.realpath@1.0.0
├─ function.prototype.name@1.1.5
├─ get-stream@6.0.1
├─ get-symbol-description@1.0.0
├─ git-raw-commits@2.0.11
├─ glob-parent@5.1.2
├─ glob@7.2.3
├─ global-dirs@0.1.1
├─ globby@11.1.0
├─ graceful-fs@4.2.10
├─ hard-rejection@2.1.0
├─ has-bigints@1.0.2
├─ has-flag@4.0.0
├─ hosted-git-info@4.1.0
├─ html-escaper@2.0.2
├─ htmlparser2@7.2.0
├─ human-signals@2.1.0
├─ husky@8.0.1
├─ imurmurhash@0.1.4
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ ini@1.3.8
├─ internal-slot@1.0.3
├─ is-alphabetical@1.0.4
├─ is-alphanumerical@1.0.4
├─ is-arrayish@0.2.1
├─ is-bigint@1.0.4
├─ is-boolean-object@1.1.2
├─ is-builtin-module@3.1.0
├─ is-callable@1.2.4
├─ is-core-module@2.9.0
├─ is-date-object@1.0.5
├─ is-extglob@2.1.1
├─ is-hexadecimal@1.0.4
├─ is-module@1.0.0
├─ is-negative-zero@2.0.2
├─ is-number-object@1.0.7
├─ is-number@7.0.0
├─ is-obj@2.0.0
├─ is-plain-obj@2.1.0
├─ is-reference@1.2.1
├─ is-regex@1.1.4
├─ is-shared-array-buffer@1.0.2
├─ is-stream@2.0.1
├─ is-string@1.0.7
├─ is-symbol@1.0.4
├─ is-text-path@1.0.1
├─ is-weakref@1.0.2
├─ isexe@2.0.0
├─ istanbul-lib-coverage@3.2.0
├─ istanbul-reports@3.1.4
├─ js-tokens@4.0.0
├─ json-parse-even-better-errors@2.3.1
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@1.0.1
├─ jsonfile@6.1.0
├─ jsonparse@1.3.1
├─ JSONStream@1.3.5
├─ kind-of@6.0.3
├─ lilconfig@2.0.5
├─ lines-and-columns@1.2.4
├─ lint-staged@13.0.2
├─ listr2@4.0.5
├─ local-pkg@0.4.1
├─ locate-path@6.0.0
├─ lodash.merge@4.6.2
├─ lodash@4.17.21
├─ log-update@4.0.0
├─ longest-streak@2.0.4
├─ loupe@2.3.4
├─ magic-string@0.25.9
├─ make-dir@3.1.0
├─ make-error@1.3.6
├─ map-obj@1.0.1
├─ markdown-table@2.0.0
├─ mdast-util-find-and-replace@1.1.1
├─ mdast-util-footnote@0.1.7
├─ mdast-util-from-markdown@0.8.5
├─ mdast-util-frontmatter@0.2.0
├─ mdast-util-gfm-autolink-literal@0.1.3
├─ mdast-util-gfm-strikethrough@0.2.3
├─ mdast-util-gfm-table@0.1.6
├─ mdast-util-gfm-task-list-item@0.1.6
├─ mdast-util-gfm@0.1.2
├─ merge2@1.4.1
├─ micromark-extension-footnote@0.3.2
├─ micromark-extension-gfm-autolink-literal@0.5.7
├─ micromark-extension-gfm-strikethrough@0.6.5
├─ micromark-extension-gfm-table@0.4.3
├─ micromark-extension-gfm-tagfilter@0.3.0
├─ micromark-extension-gfm-task-list-item@0.3.3
├─ micromark-extension-gfm@0.3.3
├─ micromatch@4.0.5
├─ mimic-fn@2.1.0
├─ min-indent@1.0.1
├─ minimist-options@4.1.0
├─ minimist@1.2.6
├─ moment@2.29.3
├─ ms@2.1.2
├─ nanoid@3.3.4
├─ natural-compare@1.4.0
├─ nock@13.2.7
├─ node-fetch@2.6.7
├─ normalize-package-data@3.0.3
├─ normalize-path@3.0.0
├─ npm-run-path@4.0.1
├─ object-inspect@1.12.2
├─ object.assign@4.1.2
├─ object.values@1.1.5
├─ onetime@5.1.2
├─ optionator@0.9.1
├─ p-limit@3.1.0
├─ p-locate@5.0.0
├─ p-map@4.0.0
├─ p-try@1.0.0
├─ parent-module@1.0.1
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.7
├─ pathval@1.1.1
├─ picocolors@1.0.0
├─ picomatch@2.3.1
├─ pidtree@0.6.0
├─ pinst@3.0.0
├─ postcss@8.4.14
├─ propagate@2.0.1
├─ punycode@2.1.1
├─ queue-microtask@1.2.3
├─ quick-lru@4.0.1
├─ read-pkg-up@7.0.1
├─ read-pkg@5.2.0
├─ readable-stream@3.6.0
├─ redent@3.0.0
├─ regexp.prototype.flags@1.4.3
├─ remark-footnotes@3.0.0
├─ remark-frontmatter@3.0.0
├─ remark-gfm@1.0.0
├─ remark-parse@9.0.0
├─ resolve-global@1.0.0
├─ resolve@1.22.1
├─ restore-cursor@3.1.0
├─ reusify@1.0.4
├─ rfdc@1.3.0
├─ rollup@2.75.7
├─ run-parallel@1.2.0
├─ rxjs@7.5.5
├─ safe-buffer@5.1.2
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ shell-escape@0.2.0
├─ side-channel@1.0.4
├─ slash@3.0.0
├─ slice-ansi@5.0.0
├─ source-map-js@1.0.2
├─ sourcemap-codec@1.4.8
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ string_decoder@1.3.0
├─ string-argv@0.3.1
├─ string.prototype.trimend@1.0.5
├─ string.prototype.trimstart@1.0.5
├─ strip-bom@3.0.0
├─ strip-final-newline@2.0.0
├─ strip-indent@3.0.0
├─ strip-json-comments@3.1.1
├─ supports-preserve-symlinks-flag@1.0.0
├─ test-exclude@6.0.0
├─ text-extensions@1.9.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ tinypool@0.1.3
├─ tinyspy@0.3.3
├─ to-regex-range@5.0.1
├─ tr46@0.0.3
├─ traverse@0.6.6
├─ trim-newlines@3.0.1
├─ trough@1.0.5
├─ ts-node@10.8.1
├─ tsconfig-paths@3.14.1
├─ tslib@1.14.1
├─ tunnel@0.0.6
├─ type-check@0.4.0
├─ type-detect@4.0.8
├─ type-fest@0.20.2
├─ typescript@4.7.4
├─ unbox-primitive@1.0.2
├─ unified@9.2.2
├─ unist-util-visit-parents@3.1.1
├─ update-section@0.3.3
├─ uri-js@4.4.1
├─ util-deprecate@1.0.2
├─ v8-compile-cache-lib@3.0.1
├─ v8-compile-cache@2.3.0
├─ v8-to-istanbul@9.0.1
├─ vfile-message@2.0.4
├─ vfile@4.2.1
├─ vite@2.9.12
├─ vitest@0.15.2
├─ webidl-conversions@3.0.1
├─ whatwg-url@5.0.0
├─ which-boxed-primitive@1.0.2
├─ which@2.0.2
├─ word-wrap@1.2.3
├─ yallist@4.0.0
├─ yaml@2.1.1
├─ yargs-parser@20.2.9
├─ yargs@16.2.0
├─ yn@3.1.1
├─ yocto-queue@0.1.0
└─ zwitch@1.0.5
Done in 14.26s.
```



</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.19
0 vulnerabilities found - Packages audited: 567
Done in 0.59s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)